### PR TITLE
Update CI scripts

### DIFF
--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -24,9 +24,37 @@ jobs:
             - name: Run tests
               run: npm test
 
+    build-autoloader:
+        name: Build autoloader
+        needs: [test]
+        if: always() #always run this job, but after others
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            id-token: write
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "20"
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Build the autoloader package
+              run: node scripts/build-autoloader.mjs
+
+            - name: Commit and push changed files to repo
+              run: |
+                  git diff
+                  git config --global user.email "
+
     bump-versions:
         name: Bump patch versions
-        needs: [test]
+        needs: [test, build-autoloader]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
         permissions:
@@ -57,7 +85,7 @@ jobs:
 
     build-docs:
         name: Build docs
-        needs: [test, bump-versions]
+        needs: [test, bump-versions, build-autoloader]
         if: always() #always run this job, but after bump-versions-on-main
         runs-on: ubuntu-latest
         permissions:
@@ -91,34 +119,6 @@ jobs:
                   git config --global user.name "GitHub Action"
                   git commit -am "[GH Actions] updated readme and/or config files" || exit 0
                   git push
-
-    build-autoloader:
-        name: Build autoloader
-        needs: [test]
-        if: always() #always run this job, but after others
-        runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            id-token: write
-        steps:
-            - name: Checkout repo
-              uses: actions/checkout@v4
-
-            - name: Setup Node.js environment
-              uses: actions/setup-node@v3
-              with:
-                  node-version: "20"
-
-            - name: Install dependencies
-              run: npm install
-
-            - name: Build the autoloader package
-              run: node scripts/build-autoloader.mjs
-
-            - name: Commit and push changed files to repo
-              run: |
-                  git diff
-                  git config --global user.email "
 
     publish:
         name: Publish packages

--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -45,7 +45,7 @@ jobs:
               run: npm install
 
             - name: Build the autoloader package
-              run: node scripts/build-autoloader.mjs
+              run: node scripts/generate-autoloader.mjs
 
             - name: Commit and push changed files to repo
               run: |

--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -45,13 +45,7 @@ jobs:
               run: npm install
 
             - name: Bump versions in package.json files
-              run: |
-                  for dir in $(find . -name 'package.json' -printf '%h\n' | sort -u)
-                  do
-                    cd $dir
-                    npm version patch -m "Bump package patch version"
-                    cd ..
-                  done
+              run:
 
             - name: Commit and push changes
               run: |

--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -26,7 +26,7 @@ jobs:
 
     bump-versions:
         name: Bump package patch versions
-        needs: test
+        needs: [test]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
         permissions:

--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -25,7 +25,7 @@ jobs:
               run: npm test
 
     bump-versions:
-        name: Bump package patch versions
+        name: Bump patch versions
         needs: [test]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
@@ -84,9 +84,6 @@ jobs:
             - name: Generate root README file
               run: node scripts/generate-root-readme.mjs
 
-            - name: Generate the autoloader package
-              run: node scripts/generate-autoloader.mjs
-
             - name: Commit and push changed files to repo
               run: |
                   git diff
@@ -95,9 +92,37 @@ jobs:
                   git commit -am "[GH Actions] updated readme and/or config files" || exit 0
                   git push
 
+    build-autoloader:
+        name: Build autoloader
+        needs: [test]
+        if: always() #always run this job, but after others
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            id-token: write
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "20"
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Build the autoloader package
+              run: node scripts/build-autoloader.mjs
+
+            - name: Commit and push changed files to repo
+              run: |
+                  git diff
+                  git config --global user.email "
+
     publish:
         name: Publish packages
-        needs: [test, bump-versions, build-docs]
+        needs: [test, bump-versions, build-autoloader, build-docs]
         runs-on: ubuntu-latest
         if: always() #always run this job, but after others
         permissions:

--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -145,22 +145,8 @@ jobs:
               run: npm install
 
             - name: Publish updated packages to JSR (dry-run)
-              run: |
-                  for dir in packages/*; do
-                    if [ -d "$dir" ]; then
-                      cd "$dir"
-                      npx jsr publish --allow-dirty --dry-run
-                      cd ..
-                    fi
-                  done
+              run: bash scripts/publish-jsr-dryrun.sh
 
             - name: Publish updated packages to JSR (on main)
               if: github.ref == 'refs/heads/main'
-              run: |
-                  for dir in packages/*; do
-                    if [ -d "$dir" ]; then
-                      cd "$dir"
-                      npx jsr publish --allow-dirty
-                      cd ..
-                    fi
-                  done
+              run: bash scripts/publish-jsr.sh

--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -4,12 +4,11 @@ on: [push, pull_request]
 
 jobs:
     test:
+        name: Test
         runs-on: ubuntu-latest
-
         permissions:
             contents: read
             id-token: write
-
         steps:
             - name: Checkout repo
               uses: actions/checkout@v4
@@ -26,6 +25,7 @@ jobs:
               run: npm test
 
     bump-versions:
+        name: Bump package patch versions
         needs: test
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
@@ -56,6 +56,7 @@ jobs:
                   git push
 
     build-docs:
+        name: Build docs
         needs: [test, bump-versions]
         if: always() #always run this job, but after bump-versions-on-main
         runs-on: ubuntu-latest
@@ -95,6 +96,7 @@ jobs:
                   git push
 
     publish:
+        name: Publish packages
         needs: [test, bump-versions, build-docs]
         runs-on: ubuntu-latest
         if: always() #always run this job, but after others

--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -50,7 +50,10 @@ jobs:
             - name: Commit and push changed files to repo
               run: |
                   git diff
-                  git config --global user.email "
+                  git config --global user.email "action@github.com"
+                  git config --global user.name "GitHub Action"
+                  git commit -am "[GH Actions] Bump patch versions" || exit 0
+                  git push
 
     bump-versions:
         name: Bump patch versions

--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -14,7 +14,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup Node.js environment
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "20"
 
@@ -37,7 +37,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup Node.js environment
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "20"
 
@@ -68,7 +68,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "20"
 
@@ -99,7 +99,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup Node.js environment
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "20"
 
@@ -137,7 +137,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup Node.js environment
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "20"
 

--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -144,6 +144,9 @@ jobs:
             - name: Install dependencies
               run: npm install
 
+            - name: Generate publishing scripts
+              run: node scripts/generate-publish-scripts.mjs
+
             - name: Publish updated packages to JSR (dry-run)
               run: bash scripts/publish-jsr-dryrun.sh
 

--- a/.github/workflows/update_publish.yml
+++ b/.github/workflows/update_publish.yml
@@ -45,7 +45,7 @@ jobs:
               run: npm install
 
             - name: Bump versions in package.json files
-              run:
+              run: bash scripts/bump-versions.sh
 
             - name: Commit and push changes
               run: |

--- a/packages/autoloader/README.md
+++ b/packages/autoloader/README.md
@@ -6,4 +6,8 @@
 
 Use in a browser with [https://esm.sh/jsr/@web-components/autoloader](https://esm.sh/jsr/@web-components/autoloader)
 
+```html
+<script src="https://esm.sh/jsr/@web-components/autoloader"></script>
+```
+
 Made by [jackcarey](https://jackcarey.co.uk).

--- a/packages/can-i-use/README.md
+++ b/packages/can-i-use/README.md
@@ -6,4 +6,8 @@
 
 Use in a browser with [https://esm.sh/jsr/@web-components/can-i-use](https://esm.sh/jsr/@web-components/can-i-use)
 
+```html
+<script src="https://esm.sh/jsr/@web-components/can-i-use"></script>
+```
+
 Made by [jackcarey](https://jackcarey.co.uk).

--- a/packages/i-cal/README.md
+++ b/packages/i-cal/README.md
@@ -6,4 +6,8 @@
 
 Use in a browser with [https://esm.sh/jsr/@web-components/i-cal](https://esm.sh/jsr/@web-components/i-cal)
 
+```html
+<script src="https://esm.sh/jsr/@web-components/i-cal"></script>
+```
+
 Made by [jackcarey](https://jackcarey.co.uk).

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -6,4 +6,8 @@
 
 Use in a browser with [https://esm.sh/jsr/@web-components/query](https://esm.sh/jsr/@web-components/query)
 
+```html
+<script src="https://esm.sh/jsr/@web-components/query"></script>
+```
+
 Made by [jackcarey](https://jackcarey.co.uk).

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -1,0 +1,8 @@
+echo "bumping package patch versions"
+for dir in $(find "$(git rev-parse --show-toplevel)/packages" -name 'package.json' -not -path '*/node_modules/*' -type f -printf '%h\n' | sort -u)
+do
+    echo "bumping $dir"
+    cd $dir
+    npm version patch -m "Bump package patch version"
+    cd ..
+done

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -1,8 +1,8 @@
 echo "bumping package patch versions"
 for dir in $(find "$(git rev-parse --show-toplevel)/packages" -name 'package.json' -not -path '*/node_modules/*' -type f -printf '%h\n' | sort -u)
-do
-    echo "bumping $dir"
-    cd $dir
-    npm version patch -m "Bump package patch version"
-    cd ..
-done
+    do
+        echo "bumping $dir"
+        cd $dir
+        npm version patch -m "Bump package patch version"
+        cd ..
+    done

--- a/scripts/generate-pkg-readmes.mjs
+++ b/scripts/generate-pkg-readmes.mjs
@@ -7,7 +7,7 @@ console.log('generating package readmes from...');
 Object.entries(pkgDetails).forEach(([dir, pkgJson]) => {
     const readmePath = path.join(dir, 'README.md');
     const esmShHref = `https://esm.sh/jsr/@web-components/${pkgJson.name}`;
-    const readmeContent = `# ${pkgJson.name}\n\n**version:** ${pkgJson.version}\n\n> ${pkgJson.description}\n\nUse in a browser with [${esmShHref}](${esmShHref})\n\nMade by [jackcarey](https://jackcarey.co.uk).`;
+    const readmeContent = `# ${pkgJson.name}\n\n**version:** ${pkgJson.version}\n\n> ${pkgJson.description}\n\nUse in a browser with [${esmShHref}](${esmShHref})\n\n\`\`\`html\n<script src="${esmShHref}"></script>\n\`\`\`\n\nMade by [jackcarey](https://jackcarey.co.uk).`;
     if (!fs.existsSync(readmePath) || fs.readFileSync(readmePath, 'utf8') !== readmeContent) {
         fs.writeFileSync(readmePath, readmeContent);
     }

--- a/scripts/generate-publish-scripts.mjs
+++ b/scripts/generate-publish-scripts.mjs
@@ -1,0 +1,19 @@
+import { pkgDetails } from './get-packages.mjs';
+import fs from 'fs';
+
+const dryRunString = Object.entries(pkgDetails).map(([dir]) => `cd "${dir}"\nnpx jsr publish --allow-dirty --dry-run`).join('\n');
+const publishString = Object.entries(pkgDetails).map(([dir]) => `cd "${dir}"\nnpx jsr publish --allow-dirty`).join('\n');
+
+const dryRunPath = './scripts/publish-jsr-dryrun.sh';
+const existingDryContent = fs.readFileSync(dryRunPath, 'utf8');
+
+if (existingDryContent !== dryRunString) {
+    fs.writeFileSync(dryRunPath, dryRunString, 'utf8');
+}
+
+const publishPath = './scripts/publish-jsr.sh';
+const existingPublishContent = fs.readFileSync(dryRunPath, 'utf8');
+
+if (existingPublishContent !== publishString) {
+    fs.writeFileSync(publishPath, publishString, 'utf8');
+}

--- a/scripts/publish-jsr-dryrun.sh
+++ b/scripts/publish-jsr-dryrun.sh
@@ -1,0 +1,7 @@
+for dir in packages/*; do
+    if [ -d "$dir" ]; then
+        cd "$dir"
+        npx jsr publish --allow-dirty --dry-run
+        cd ..
+    fi
+done

--- a/scripts/publish-jsr.sh
+++ b/scripts/publish-jsr.sh
@@ -1,0 +1,7 @@
+for dir in packages/*; do
+    if [ -d "$dir" ]; then
+        cd "$dir"
+        npx jsr publish --allow-dirty
+        cd ..
+    fi
+done


### PR DESCRIPTION
using shell scripts for:
- version bumping
- publishing to JSR

a node script is used to generate a shell script for publishing since the JSR publish command doesn't want to loop for some reason...